### PR TITLE
Add quick timer and boss KO effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,9 @@
         </div>
     </div>
 
+    <!-- ボス撃破演出 -->
+    <div id="bossKo" class="boss-ko">💥 BOSS KO 💥</div>
+
     <!-- 効果音用（表示されない） -->
     <audio id="correctSound" preload="auto">
         <source src="data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1fdJivrJBhNjVgodDbq2EcBj+a2/LDciUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmcfCUOb3O2KVhMKNovR7K1VFAo5k9n3s2EcBzGM1enHcSUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmcfCUOb3O2KVhMKNovR7K1VFAo5k9n3s2EcBzGM1enHcSUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmcfCUOb3O2KVhMKNovR7K1VFAo5k9n3s2EcBzGM1enHcSUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmcfCUOb3O2KVhMKNovR7K1VFAo5k9n3s2EcBzGM1enHcSUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmcfCUOb3O2KVhMKNovR7K1VFAo5k9n3s2EcBzGM1enHcSUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmcfCUOb3O2KVhMKNovR7K1VFAo5k9n3s2EcBzGM1enHcSUF" type="audio/wav">

--- a/style.css
+++ b/style.css
@@ -361,6 +361,30 @@ button:active {
   cursor: not-allowed;
 }
 
+/* ボス撃破表示 */
+.boss-ko {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  font-size: 4rem;
+  color: #ff0000;
+  text-shadow: 0 0 20px #ff0000;
+  pointer-events: none;
+  z-index: 1000;
+  display: none;
+}
+
+.boss-ko.active {
+  display: block;
+  animation: bossKoAnim 1s forwards;
+}
+
+@keyframes bossKoAnim {
+  from { transform: translate(-50%, -50%) scale(1.5); opacity: 1; }
+  to { transform: translate(-50%, -50%) scale(0); opacity: 0; }
+}
+
 /* 結果画面 */
 #resultScreen {
   display: flex;


### PR DESCRIPTION
## Summary
- flash background and boss speech on answers
- add fast 3-second timer for each question
- show "BOSS KO" effect when defeating a boss

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_688a9a2dc05483308e8b94b9f4938ef4