### PR TITLE
Shrink stage select buttons and restyle central AI

### DIFF
--- a/style.css
+++ b/style.css
@@ -145,17 +145,21 @@ button:active {
   gap: 15px;
   max-width: 600px;
   margin: 0 auto 30px;
+  grid-auto-rows: 80px;
 }
 
 .zone-box {
   background: rgba(0, 255, 0, 0.05);
   border: 2px solid #00ff00;
-  padding: 20px;
+  padding: 10px;
   text-align: center;
   cursor: pointer;
   transition: all 0.3s ease;
   border-radius: 8px;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .zone-box:hover {
@@ -236,25 +240,39 @@ button:active {
 }
 
 .zone-box.omega {
-  background: linear-gradient(135deg, rgba(255, 0, 0, 0.1), rgba(255, 255, 0, 0.1));
-  border-color: #ff0000;
+  background: linear-gradient(135deg, rgba(0, 255, 255, 0.2), rgba(255, 0, 255, 0.1));
+  border-color: #00ffff;
   grid-column: 2;
   grid-row: 2;
+  width: 80px;
+  height: 80px;
+  margin: auto;
+  aspect-ratio: 1 / 1;
+  border-radius: 0;
+  box-shadow: 0 0 20px #00ffff;
+  transform: scale(2);
+  z-index: 1;
 }
 
 .zone-box.omega:hover {
-  box-shadow: 0 0 20px #ff0000;
+  box-shadow: 0 0 25px #00ffff;
+}
+
+.zone-box.omega .zone-number,
+.zone-box.omega .zone-name {
+  color: #00ffff;
+  text-shadow: 0 0 5px #00ffff;
 }
 
 .zone-number {
-  font-size: 2rem;
+  font-size: 1.5rem;
   font-weight: bold;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 }
 
 .zone-name {
-  font-size: 1.2rem;
-  margin-bottom: 10px;
+  font-size: 0.9rem;
+  margin-bottom: 5px;
 }
 
 .zone-status {
@@ -677,11 +695,12 @@ button:active {
   .zone-grid {
       grid-template-columns: repeat(2, 1fr);
       gap: 10px;
+      grid-auto-rows: 60px;
   }
-  
+
   .zone-box.omega {
       grid-column: 1 / -1;
-      grid-row: auto;
+      grid-row: 2 / span 2;
   }
   
   .quiz-header {
@@ -721,18 +740,19 @@ button:active {
   
   .zone-grid {
       gap: 8px;
+      grid-auto-rows: 60px;
   }
-  
+
   .zone-box {
-      padding: 15px;
+      padding: 8px;
   }
-  
+
   .zone-number {
-      font-size: 1.5rem;
+      font-size: 1.2rem;
   }
-  
+
   .zone-name {
-      font-size: 1rem;
+      font-size: 0.8rem;
   }
   
   .question-box {


### PR DESCRIPTION
## Summary
- Halve stage select button height with tighter grid rows and reduced padding/fonts
- Rework central AI zone into glowing cyan square to emphasize its presence
- Adjust mobile styles to keep compact buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b6957e6c88330adc36a7e71bd1ab9