### PR TITLE
Fix overlapping zone selection button

### DIFF
--- a/style.css
+++ b/style.css
@@ -717,7 +717,7 @@ button:active {
 
   .zone-box.omega {
       grid-column: 1 / -1;
-      grid-row: 2 / span 2;
+      /* autoplace without forcing a specific row to avoid overlap */
   }
   
   .quiz-header {


### PR DESCRIPTION
## Summary
- prevent Omega zone button from overlapping other selections on small screens by removing forced grid row placement

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688d3dd980ec8330a1f2041fb2888d05