### PR TITLE
Fix overlapping button styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,6 +38,10 @@ button {
   text-transform: uppercase;
   font-weight: bold;
   border-radius: 4px;
+  display: block;
+  width: 100%;
+  max-width: 300px;
+  margin: 10px auto;
 }
 
 button:hover {
@@ -789,5 +793,21 @@ button:active {
   .answer-btn {
       padding: 12px;
       font-size: 0.9rem;
+  }
+
+  button {
+      font-size: 14px;
+      padding: 10px 16px;
+      max-width: 100%;
+  }
+
+  .main-btn {
+      font-size: 16px;
+      padding: 12px 20px;
+  }
+
+  .sub-btn {
+      font-size: 12px;
+      padding: 8px 16px;
   }
 }


### PR DESCRIPTION
## Summary
- prevent buttons from stretching excessively and overlapping by constraining width and centering them
- add responsive button sizing for small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d7f7c1b788330a7aae79c98d5e344