### PR TITLE
Adjust zone select buttons for clarity

### DIFF
--- a/style.css
+++ b/style.css
@@ -163,7 +163,7 @@ button:active {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  aspect-ratio: 1 / 1;
+  aspect-ratio: 2 / 1;
   overflow: hidden;
 }
 
@@ -716,7 +716,6 @@ button:active {
   .zone-grid {
       grid-template-columns: repeat(2, 1fr);
       gap: 10px;
-      grid-auto-rows: 60px;
   }
 
   .zone-box.omega {
@@ -767,7 +766,6 @@ button:active {
   
   .zone-grid {
       gap: 8px;
-      grid-auto-rows: 60px;
   }
 
   .zone-box {


### PR DESCRIPTION
## Summary
- Keep zone selection buttons from overlapping by using an aspect ratio that halves their height
- Remove fixed grid row heights in responsive layouts for consistent spacing

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d96d00fac83309ddf60a9f79bbbd2