### PR TITLE
Swap central AI with science and social zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,16 +35,16 @@
                 <div class="zone-name">国語</div>
                 <div class="zone-status">🔒</div>
             </div>
+            <div class="zone-box omega" data-zone="omega">
+                <div class="zone-name">中央AI</div>
+                <div class="zone-status">🔒</div>
+            </div>
             <div class="zone-box" data-zone="3">
                 <div class="zone-name">理科</div>
                 <div class="zone-status">🔒</div>
             </div>
             <div class="zone-box" data-zone="4">
                 <div class="zone-name">社会</div>
-                <div class="zone-status">🔒</div>
-            </div>
-            <div class="zone-box omega" data-zone="omega">
-                <div class="zone-name">中央AI</div>
                 <div class="zone-status">🔒</div>
             </div>
             <div class="zone-box" data-zone="5">

--- a/style.css
+++ b/style.css
@@ -242,8 +242,6 @@ button:active {
 .zone-box.omega {
   background: linear-gradient(135deg, rgba(0, 255, 255, 0.2), rgba(255, 0, 255, 0.1));
   border-color: #00ffff;
-  grid-column: 2;
-  grid-row: 2;
   border-radius: 0;
   box-shadow: 0 0 20px #00ffff;
   z-index: 1;


### PR DESCRIPTION
## Summary
- Reordered zone grid so the central AI occupies former science slot and science/social shift accordingly
- Removed fixed grid positioning from central AI style to allow new layout

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dcf7063d48330a9754bb8529fba29