### PR TITLE
Arrange quiz answers in two-column layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -342,7 +342,7 @@ button:active {
 
 .answers {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 15px;
   margin-bottom: 30px;
 }
@@ -356,6 +356,8 @@ button:active {
   align-items: center;
   justify-content: center;
   width: 100%;
+  margin: 0;
+  max-width: none;
 }
 
 .answer-btn.correct {
@@ -714,9 +716,10 @@ button:active {
       gap: 10px;
       text-align: center;
   }
-  
+
   .answers {
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 10px;
   }
   
   .result-actions,


### PR DESCRIPTION
## Summary
- Make quiz option list a two-column grid for compact layout.
- Remove extra button spacing so four choices display without vertical scrolling.
- Ensure responsive styles keep two-column layout on small screens.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eb41b3f748330ba7004d01418f8ac